### PR TITLE
Add support for converting wiki links to markdown links. Also add support for removing links if they don't exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ let ast = fromMarkdown('[[Test Page]]', {
 #### `toMarkdown`
 
 * `options.aliasDivider [String]`: a string to be used as the divider for aliases. See the section below on [Aliasing pages](#aliasing-pages). Defaults to `":"`.
+* `options.convertToLink [Boolean]`: if this is set to `true`, then the generated markdown will have markdown links in place of wiki links. In other words, a wiki link that looks like this: `[[Real Page:Page Alias]]`, will be converted to a markdown link like this: `[Page Alias](#/page/real_page)`.
+* `options.removeLinkIfNotExists [Boolean]`: if this is set to `true`, then all wiki links, which have a target that does not exist in `options.permalinks`, will be converted to plain text. In other words, if `options.permalinks` looks like this: `["real_page"]`, then a wiki link that looks like this: `[[Real Page: Page Alias]]`, will remain as-is in the generated markdown. However, a wiki link that look like this: `[[Non existing page: Page Alias]]`, will be converted to the text `Page Alias` in the generated markdown. This option can be used alongside the `convertToLink` option.
 
 ### Aliasing pages
 


### PR DESCRIPTION
Hi,

Thank you for creating [your remark plugin](https://github.com/landakram/remark-wiki-link). I found it vey useful. 

I found myself needing to use this plugin in a way that is not yet supported. So I created [another very similar plugin](https://github.com/dannyvelas/publish/blob/main/src/wiki-link-plugin/index.ts).

I figured that it might be nice to contribute to your code with the added functionality of my plugin. The only difference is that my plugin allows one to convert wiki links to markdown links. It also allows one to remove links if they don't exist.

If you are okay with merging this in, I can make another PR to update your remark plugin. And, I will be able to deprecate my plugin and use your remark plugin in its place. 

If you prefer not to merge this in, that is totally fine. I will continue to use my own plugin.

Thanks again